### PR TITLE
テーブル定義周りの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.backend/__pycache__/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ https://qiita.com/gon0821/items/f9e3bcbb6cb01d4ef7fa
 ## 自動対話型の API ドキュメント(Swagger UI)
 
 `http://localhost:8000/docs`# SF6DB_TEST
+
+### git　追加手順
+`git add .`
+`git commit -m "コミットメッセージ"`
+`git push`

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,14 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+MYSQL_DATABASE_URL = "mysql://user:user-pass@mysql:3306/mydb"
+
+engine = create_engine(MYSQL_DATABASE_URL)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+# クラスを返す関数 declarative_base() を使用
+# このクラスを継承して、各データベースモデルやクラス（ORMモデル）を作成します

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from database import Base
+
+class Character(Base):
+    __tablename__ = "characters"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(20), unique=True, index=True)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class Character(BaseModel):
+  name: str


### PR DESCRIPTION
**【作業内容】**
・FastAPIを用いたテーブル定義および作成のpython初期ファイル類の構築
・__pycache__のgitignoreの設定

**【エラー備忘録】**
`ImportError: attempted relative import with no known parent package`
・pythonで他モジュール（ファイル）インポートする際によく見かけるエラーだそう
・相対パスでのインポートとかで起こるらしい
・色々設定方法もあるらしいけどややこしそう…。「.」や「..」で階層を読み込むのをやめたら一旦解決した。（[参考](https://qiita.com/u943425f/items/bd94a30b52c9296e942d)）

`sqlalchemy.exc.CompileError: (in table 'characters', column 'name'): VARCHAR requires a length on dialect mysql`
・MySQLのテーブル定義において、VARCHAR 型のカラムに長さが指定されていないために発生しています。MySQLでは、VARCHAR 型のカラムを定義する際に、その長さ（文字数）を必ず指定する必要があります。（models.pyにてString(20)と記載し、文字数を指定した）
