### PR TITLE
actions/checkout を使ってリポジトリの内容を取得する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,8 @@ on:
       - dev
 
 jobs:
-  echo_hello_world:
+  test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - run: npm run lint


### PR DESCRIPTION
GitHub Actionsでソースコードを取得するためには、actions/checkout を使ってリポジトリの内容を取得する必要があります。それを追加することで、問題を解決できます。

actions/checkout@v2 は、GitHub Actionsがリポジトリの内容を取得するためのアクションです。これがないと、GitHub Actionsはリポジトリのファイルにアクセスできず、package.json などのファイルも読み込めません。

GitHub Actionsのアクションは、バージョン管理されており、v1、v2 などの形式でリリースされます。バージョン番号を指定することで、特定の安定したバージョンのアクションを使用することができます。これにより、アクションが更新されても、意図しない変更や不具合がプロジェクトに影響を与えないようにすることができます。

例えば：

actions/checkout@v1 は、v1 バージョンの最新のリリースを使用します。
actions/checkout@v2 は、v2 バージョンの最新のリリースを使用します。
バージョン番号の後に - を付けることで、特定のマイナーリリースやパッチリリースを指定することもできます（例: v2.3.4）。

通常、アクションのドキュメントやGitHub Marketplaceで、使用するアクションのバージョンを確認することができます。また、安定性を保つために、特定のバージョンを明示的に指定するのが一般的です。

参考：
https://qiita.com/shun198/items/14cdba2d8e58ab96cf95